### PR TITLE
Code Hygiene: remove deprecated code

### DIFF
--- a/common.py
+++ b/common.py
@@ -651,9 +651,9 @@ class LogInstallOutput(object):
                 self.console.write(txt)
             except:
                 self.console.write(repr(txt))
-            if txt <> '\n':
+            if txt != '\n':
                 self.output.append(txt)
-                if txt and txt[-1]<>u'\n':
+                if txt and txt[-1] != u'\n':
                     txtdb = txt+u'\n'
                 else:
                     txtdb = txt
@@ -1655,7 +1655,7 @@ class WaptDB(WaptBaseDB):
                     else:
                         # get depends of the most recent matching entry
                         # TODO : use another older if this can limit the number of packages to install !
-                        depends = [s.strip() for s in entries[-1].depends.split(',') if s.strip()<>'']
+                        depends = [s.strip() for s in entries[-1].depends.split(',') if s.strip() != '']
                         available_depends = []
                         for d in depends:
                             if self.packages_matching(d):
@@ -1825,7 +1825,7 @@ class WaptRepo(object):
                         return True
                 return False
 
-            if self.dnsdomain and self.dnsdomain <> '.':
+            if self.dnsdomain and self.dnsdomain != '.':
                 # find by dns SRV _wapt._tcp
                 try:
                     resolv = dns.resolver.get_default_resolver()
@@ -2018,7 +2018,7 @@ class WaptRepo(object):
         endline = 0
 
         def add(start,end):
-            if start <> end:
+            if start != end:
                 package = PackageEntry()
                 package.load_control_from_wapt(packages_lines[start:end])
                 logger.info(u"%s (%s)" % (package.package,package.version))
@@ -2105,7 +2105,7 @@ class WaptHostRepo(WaptRepo):
                 host_package_date = httpdatetime2isodate(host_request.headers['last-modified'])
                 package = None
                 if host_package_date:
-                    if force or host_package_date <> waptdb.get_param(host_cachedate) or not waptdb.packages_matching(host):
+                    if force or host_package_date != waptdb.get_param(host_cachedate) or not waptdb.packages_matching(host):
                         host_package = requests.get(host_package_url,proxies=self.proxies,verify=False,headers={'cache-control':'no-cache','pragma':'no-cache'})
                         host_package.raise_for_status
 
@@ -2331,11 +2331,11 @@ class Wapt(object):
         """Update configuration parameters to supplied inifilename
         """
         for key in self.config.defaults():
-            if hasattr(self,key) and getattr(self,key) <> self.config.defaults()[key]:
+            if hasattr(self,key) and getattr(self,key) != self.config.defaults()[key]:
                 logger.debug('update config global.%s : %s' % (key,getattr(self,key)))
                 self.config.set('global',key,getattr(self,key))
         repositories_names = ','.join([ r.name for r in self.repositories if r.name not in ('global','wapt-host')])
-        if self.config.has_option('global','repositories') and repositories_names <> '':
+        if self.config.has_option('global','repositories') and repositories_names != '':
             self.config.set('global','repositories',repositories_names)
         self.config.write(open(self.config_filename,'wb'))
 
@@ -2422,7 +2422,7 @@ class Wapt(object):
         killed=[]
         for p in psutil.process_iter():
             try:
-                if p.pid <> os.getpid() and (p.create_time() < mindate) and p.name() in ('wapt-get','wapt-get.exe'):
+                if p.pid != os.getpid() and (p.create_time() < mindate) and p.name() in ('wapt-get','wapt-get.exe'):
                     logger.debug('Killing process tree of pid %i' % p.pid)
                     setuphelpers.killtree(p.pid)
                     logger.debug('Killing pid %i' % p.pid)
@@ -2558,7 +2558,7 @@ class Wapt(object):
         errors = []
         for (filename,sha1) in manifest:
             fullpath = os.path.join(rootdir,filename)
-            if sha1 <> sha1_for_file(fullpath):
+            if sha1 != sha1_for_file(fullpath):
                 errors.append(filename)
         return errors
 
@@ -3139,7 +3139,7 @@ class Wapt(object):
 
                 for (fn,sha1) in manifest:
                     if fn == 'WAPT\\control':
-                        if sha1 <> sha1_for_data(control.encode('utf8')):
+                        if sha1 != sha1_for_data(control.encode('utf8')):
                             raise Exception("WAPT/control file of %s is corrupted, sha1 digests don't match" % fname)
                         break
                 # Merge updated control data
@@ -3168,7 +3168,7 @@ class Wapt(object):
                         for k in result.as_dict():
                             p[k] = result[k]
 
-                    if not result or result['install_status']<>'OK':
+                    if not result or result['install_status'] != 'OK':
                         actions['errors'].append([request,p])
                         logger.critical(u'Package %s not installed due to errors' %(request,))
                 except Exception as e:
@@ -3329,7 +3329,7 @@ class Wapt(object):
                 else:
                     logger.debug(u'uninstall key not registered in local DB status.')
 
-                if mydict['install_status'] <> 'ERROR':
+                if mydict['install_status'] != 'ERROR':
                     try:
                         self.uninstall(package)
                     except Exception as e:
@@ -3454,7 +3454,7 @@ class Wapt(object):
 
         inv = self.inventory()
         # store uuid for future use to avoid the use of dmidecode
-        if not self.read_param('uuid') or self.read_param('uuid') <> inv['uuid']:
+        if not self.read_param('uuid') or self.read_param('uuid') != inv['uuid']:
             self.write_param('uuid',inv['uuid'])
         if force:
             inv['force']=True
@@ -3494,7 +3494,7 @@ class Wapt(object):
                     logger.warning('Unable to update server status : %s' % ensure_unicode(e))
                 result = json.loads(req.content)
                 # force register if computer has not been registered or hostname has changed
-                if not result or not 'host' in result or result['host']['computer_fqdn'] <> setuphelpers.get_hostname():
+                if not result or not 'host' in result or result['host']['computer_fqdn'] != setuphelpers.get_hostname():
                     self.register_computer()
                 return result
             else:
@@ -3745,7 +3745,7 @@ class Wapt(object):
                         logger.debug(u'Deleting directory %s' % dir )
                         shutil.rmtree(dir)
 
-                if package_group<>hosts:
+                if package_group != hosts:
                     if self.after_upload:
                         print 'Run after upload script...'
                         print ensure_unicode(self.run(self.after_upload % cmd_dict))
@@ -4221,7 +4221,7 @@ class Wapt(object):
 
         if depends:
             # use supplied list of packages
-            entry.depends = ','.join([u'%s' % p for p in depends if p and p<>packagename ])
+            entry.depends = ','.join([u'%s' % p for p in depends if p and p != packagename ])
 
         codecs.open(control_filename,'w',encoding='utf8').write(entry.ascontrol())
 
@@ -4337,7 +4337,7 @@ class Wapt(object):
     def is_wapt_package_file(self,filename):
         """Return PackageEntry if filename is a wapt package or False"""
         (root,ext)=os.path.splitext(filename)
-        if ext<>'.wapt' or not os.path.isfile(filename):
+        if ext != '.wapt' or not os.path.isfile(filename):
             return False
         try:
             entry = PackageEntry().load_control_from_wapt(filename,calc_md5=False)
@@ -4491,7 +4491,7 @@ class Wapt(object):
         if os.path.isdir(packagename):
             source_control = PackageEntry().load_control_from_wapt(packagename)
             target_directory = self.get_default_development_dir(newname,section=source_control.section)
-            if packagename<>target_directory:
+            if packagename != target_directory:
                 shutil.copytree(packagename,target_directory)
         elif os.path.isfile(packagename):
             source_filename = packagename

--- a/keyfinder.py
+++ b/keyfinder.py
@@ -307,7 +307,7 @@ def GetMSDPID3(sHivePath):
             sProdID = reg_getvalue(key,'ProductID')
             sText = ''
             for i in range(5,31):
-                if HexBuf[i] <> '\x00':
+                if HexBuf[i] != '\x00':
                     sText += HexBuf[i]
             #Compare Product ID's
             if sText == sProdID:
@@ -319,7 +319,7 @@ def GetMSDPID3(sHivePath):
             # Edition ID
             sText = '';
             for i in range(33,45):
-                if HexBuf[i] <> "\x00":
+                if HexBuf[i] != "\x00":
                     sText = sText + HexBuf[i]
             result['product_partnr'] = sText
 
@@ -337,7 +337,7 @@ def GetMSDPID3(sHivePath):
                 elif dwChannel==3:
                     result['product_source'] = 'Installed from ''Volume'' media.'
 
-            result['product_key'] = msoKeyDecode( HexBuf,wMajor<>3)
+            result['product_key'] = msoKeyDecode( HexBuf,wMajor != 3)
         elif iBinarySize == 0:
             result['product_key'] = 'The CD Key data is empty!'
         else:

--- a/setuphelpers.py
+++ b/setuphelpers.py
@@ -128,7 +128,7 @@ def ensure_unicode(data):
         except:
            pass
     except:
-        if logger.level <> logging.DEBUG:
+        if logger.level != logging.DEBUG:
             return("Error in ensure_unicode / %s"%(repr(data)))
         else:
             raise
@@ -347,7 +347,7 @@ def register_ext(appname,fileext,shellopen,icon=None,otherverbs=[]):
         rootpath = os.path.dirname(path)
         name = os.path.basename(path)
         k = reg_openkey_noredir(key,path,sam=KEY_READ | KEY_WRITE,create_if_missing=True)
-        if value<>None:
+        if value != None:
             reg_setvalue(k,'',value)
     filetype = appname+fileext
     setvalue(HKEY_CLASSES_ROOT,fileext,filetype)
@@ -1568,10 +1568,10 @@ if __name__=='__main__':
     assert not service_is_running('waptservice')
     service_start('waptservice')
     assert not service_installed('wapt')
-    assert get_computername() <> ''
+    assert get_computername() != ''
     #print getloggedinusers()
-    #assert get_domainname() <> ''
-    assert get_msi_properties(glob.glob('C:\\Windows\\Installer\\*.msi')[0])['Manufacturer'] <> ''
-    assert installed_softwares('offi')[0]['uninstall_string'] <> ''
-    assert get_file_properties('c:\\wapt\\waptservice.exe')['FileVersion'] <>''
-    assert get_file_properties('c:\\wapt\\wapt-get.exe')['FileVersion'] <> ''
+    #assert get_domainname() != ''
+    assert get_msi_properties(glob.glob('C:\\Windows\\Installer\\*.msi')[0])['Manufacturer'] != ''
+    assert installed_softwares('offi')[0]['uninstall_string'] != ''
+    assert get_file_properties('c:\\wapt\\waptservice.exe')['FileVersion'] != ''
+    assert get_file_properties('c:\\wapt\\wapt-get.exe')['FileVersion'] != ''

--- a/wapt-get.py
+++ b/wapt-get.py
@@ -169,7 +169,7 @@ class JsonOutput(object):
 
     def write(self,txt):
         txt = ensure_unicode(txt)
-        if txt <> '\n':
+        if txt != '\n':
             logger.info(txt)
             self.output.append(txt)
 
@@ -287,7 +287,7 @@ def main():
                     jsonresult['result'] = result
                 else:
                     print u"\nResults :"
-                    if action<>'download':
+                    if action != 'download':
                         for k in ('install','additional','upgrade','skipped','errors'):
                             if result.get(k,[]):
                                 print u"\n=== %s packages ===\n%s" % (k,'\n'.join( ["  %-30s | %s (%s)" % (s[0],s[1].package,s[1].version) for s in  result[k]]),)
@@ -684,7 +684,7 @@ def main():
                             cmd_dict =  {'waptfile': files_list,'waptdir':package_group[0]}
                             print mywapt.upload_package(cmd_dict)
 
-                            if package_group<>hosts:
+                            if package_group != hosts:
                                 if mywapt.after_upload:
                                     print 'Run after upload script...'
                                     print setuphelpers.run(mywapt.after_upload % cmd_dict)
@@ -734,7 +734,7 @@ def main():
                         cmd_dict =  {'waptfile': files_list,'waptdir':package_group[0]}
 
                         print mywapt.upload_package(cmd_dict)
-                        if package_group<>hosts:
+                        if package_group != hosts:
                             if mywapt.after_upload:
                                 print 'Run after upload script...'
                                 print setuphelpers.run(mywapt.after_upload % cmd_dict)

--- a/waptpackage.py
+++ b/waptpackage.py
@@ -70,7 +70,7 @@ def parse_major_minor_patch_build(version):
     verinfo = match.groupdict()
 
     def int_or_none(name):
-        if name in verinfo and verinfo[name] <> None :
+        if name in verinfo and verinfo[name] != None :
             return int(verinfo[name])
         else:
             return None
@@ -83,8 +83,8 @@ def parse_major_minor_patch_build(version):
 
 
 def make_version(major_minor_patch_build):
-    p1 = u'.'.join( [ "%s" % major_minor_patch_build[p] for p in ('major','minor','patch','subpatch') if major_minor_patch_build[p]<>None])
-    if major_minor_patch_build['packaging']<>None:
+    p1 = u'.'.join( [ "%s" % major_minor_patch_build[p] for p in ('major','minor','patch','subpatch') if major_minor_patch_build[p] != None])
+    if major_minor_patch_build['packaging'] != None:
         return '-'.join([p1,major_minor_patch_build['packaging']])
     else:
         return p1
@@ -189,7 +189,7 @@ class PackageEntry(object):
     def match(self, match_expr):
         """Return True if package entry match a package string like 'tis-package (>=1.0.1-00)"""
         pcv = REGEX_PACKAGE_CONDITION.match(match_expr).groupdict()
-        if pcv['package'] <> self.package:
+        if pcv['package'] != self.package:
             return False
         else:
             if 'operator' in pcv and pcv['operator']:
@@ -347,7 +347,7 @@ sources      : %(sources)s
         """Increment build number (last part of version)"""
         version_parts = self.parse_version()
         for part in ('packaging','subpatch','patch','minor','major'):
-            if part in version_parts and version_parts[part] <> None :
+            if part in version_parts and version_parts[part] != None :
                 version_parts[part] = "%i" % (int(version_parts[part])+1,)
                 self.version = make_version(version_parts)
                 return
@@ -404,7 +404,7 @@ class WaptLocalRepo(object):
             endline = 0
 
             def add(start,end):
-                if start <> end:
+                if start != end:
                     package = PackageEntry()
                     package.load_control_from_wapt(packages_lines[start:end])
                     logger.info(u"%s (%s)" % (package.package,package.version))

--- a/waptserver/scripts/postconf.py
+++ b/waptserver/scripts/postconf.py
@@ -24,11 +24,11 @@ if postconf.yesno("Do you want to launch post configuration tool ?") == postconf
             waptserver_ini.set('options','mongodb_ip','127.0.0.1')
         elif tag == "2":
             (code,mongodb_ip) = postconf.inputbox("IP address of the mongodb server:")
-            if code<>postconf.DIALOG_OK:
+            if code != postconf.DIALOG_OK:
                 exit(1)
             else:
                 waptserver_ini.set('options','mongodb_ip',mongodb_ip)
-        elif code<>postconf.DIALOG_OK:
+        elif code != postconf.DIALOG_OK:
             exit(1)
 
     code, tag = postconf.menu("Mongodb server port: ",
@@ -39,15 +39,15 @@ if postconf.yesno("Do you want to launch post configuration tool ?") == postconf
             waptserver_ini.set('options','mongodb_port','27017')
         elif tag == "2":
             (code,mongodb_port) = postconf.inputbox("mongodb server port: ")
-            if code<>postconf.DIALOG_OK:
+            if code != postconf.DIALOG_OK:
                 exit(1)
             else:
                 waptserver_ini.set('options','mongodb_port',mongodb_port)
-        elif code<>postconf.DIALOG_OK:
+        elif code != postconf.DIALOG_OK:
             exit(0)
 
     (code,wapt_password) = postconf.passwordbox("wapt server password:  ")
-    if code<>postconf.DIALOG_OK:
+    if code != postconf.DIALOG_OK:
         exit(0)
     else:
         password = hashlib.sha512(wapt_password).hexdigest()

--- a/waptserver/waptserver.py
+++ b/waptserver/waptserver.py
@@ -222,7 +222,7 @@ def get_host_list():
             host.pop("_id")
             if search_filter:
                 for key in search_filter:
-                    if host.has_key(key) and search in json.dumps(host[key]).lower():
+                    if key in host and search in json.dumps(host[key]).lower():
                         host["softwares"] = ""
                         host["packages"] = ""
                         list_hosts.append(host)
@@ -302,7 +302,7 @@ def delete_host(uuid=""):
 @app.route('/client_software_list/<string:uuid>')
 def get_client_software_list(uuid=""):
     softwares = get_host_data(uuid, filter={"softwares":1})
-    if softwares.has_key('softwares'):
+    if 'softwares' in softwares:
         return  Response(response=json.dumps(softwares['softwares']),
                          status=200,
                          mimetype="application/json")
@@ -345,7 +345,7 @@ def host_packages(uuid=""):
         if not packages:
             raise Exception('No host with uuid %s'%uuid)
         repo_packages = packagesFileToList(os.path.join(wapt_folder, 'Packages'))
-        if packages.has_key('packages'):
+        if 'packages' in packages:
             for p in packages['packages']:
                 package = PackageEntry()
                 package.load_control_from_dict(p)
@@ -369,7 +369,7 @@ def get_client_package_list(uuid=""):
         if not packages:
             raise Exception('No host with uuid %s'%uuid)
         repo_packages = packagesFileToList(os.path.join(wapt_folder, 'Packages'))
-        if packages.has_key('packages'):
+        if 'packages' in packages:
             for p in packages['packages']:
                 package = PackageEntry()
                 package.load_control_from_dict(p)
@@ -762,9 +762,9 @@ def deploy_wapt():
 
         if request.method == 'POST':
             d = json.loads(request.data)
-            if not d.has_key('auth'):
+            if 'auth' not in d:
                 raise Exception("Les informations d'authentification sont manquantes")
-            if not d.has_key('computer_fqdn'):
+            if 'computer_fqdn' not in d:
                 raise Exception(u"Il n'y a aucuns ordinateurs de renseigné")
 
             auth_file = tempfile.mkstemp("wapt")[1]

--- a/waptservice/waptservice.py
+++ b/waptservice/waptservice.py
@@ -883,7 +883,7 @@ class EventsPrinter:
 
     def write(self, text):
         '''Logs written output to listeners'''
-        if text and text <> '\n':
+        if text and text != '\n':
             if self.events:
                 self.events.send_multipart(['PRINT',(setuphelpers.ensure_unicode(text)).encode('utf8')])
             self.logs.append(setuphelpers.ensure_unicode(text))


### PR DESCRIPTION
pep8 reports two deprecated python constructs:

```
W601 .has_key() is deprecated, use 'in'
W603 '<>' is deprecated, use '!='
```

The .has_key() changes probably need to be carefully reviewed.
