### PR TITLE
Fix quote misuse in waptservice/waptservice.py

### DIFF
--- a/waptservice/waptservice.py
+++ b/waptservice/waptservice.py
@@ -1545,7 +1545,7 @@ class WaptServiceRestart(WaptTask):
         tmp_bat.close()
         setuphelpers.create_onetime_task('waptservicerestart',tmp_bat.name,'')
         """
-        setuphelpers.create_onetime_task('waptservicerestart','cmd.exe','/C \'net stop waptservice & net start waptservice\'"')
+        setuphelpers.create_onetime_task('waptservicerestart','cmd.exe','/C net stop waptservice & net start waptservice')
         output = __(u'WaptService restart planned')
         self.result = {'result':'OK','message':output}
 


### PR DESCRIPTION
- the http route /waptservicerestart wasn't working properly due to bad quotes
- executing 'cmd.exe /C command1 & command2', without quotes, works properly