### PR TITLE
Tweak wapt-get add-upgrade-shutdown command - Fixes #24

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Le déploiement de logiciels (Firefox, MS Office,...) à partir d'une console de
 gestion centrale est maintenant possible. WAPT s'inspire fortement du
 gestionnaire de paquets du système GNU/Linux Debian apt, d'où son nom.
 
-Plus d'informations sur: http://dev.tranquil.it/index.php/WAPT
+Plus d'informations sur: https://www.wapt.fr/
 
 Licensing
 =========

--- a/setuphelpers.py
+++ b/setuphelpers.py
@@ -1859,30 +1859,11 @@ def add_shutdown_script(cmd,parameters):
             update_gpt = True
         else:
             ext = gptini.get('General','gPCMachineExtensionNames').strip().replace('][','],[').split(',')
-            # fix malformed array : should be a list of pairs [{i1}{i2}][{j1}{j2}][{k1}{k2}]
-            if ext:
-                # calc a new list of pairs
-                newext = []
-                bad = False
-                for e in ext:
-                    e = e.strip('[]')
-                    guids = e.replace('}{','},{').split(',')
-                    if len(guids)>2:
-                        bad = True
-                        i = 0
-                        while i < len(guids):
-                            newext.append('[%s%s]'%(guids[i],guids[i+1]))
-                            i+=2
-                    else:
-                        newext.append(e)
-                if bad:
-                    ext = newext
-                    update_gpt = True
-
             if not '[{42B5FAAE-6536-11D2-AE5A-0000F87571E3}{40B6664F-4972-11D1-A7CA-0000F87571E3}]' in ext:
                 ext.append('[{42B5FAAE-6536-11D2-AE5A-0000F87571E3}{40B6664F-4972-11D1-A7CA-0000F87571E3}]')
                 update_gpt = True
-            gptini.set('General','gPCMachineExtensionNames',''.join(ext))
+
+            gptini.set('General','gPCMachineExtensionNames',''.join(sorted(ext)))
         # increment version
         if gptini.has_option('General','Version'):
             version = gptini.getint('General','Version')


### PR DESCRIPTION
Fixed gPCMachineExtensionNames handler in `add_shutdown_script()`

Removed malformed array fixer, as it was based on wrong assumption that gPCMachineExtensionNames was a GUID pair list and could break working GPO.
See https://technet.microsoft.com/en-us/library/cc978247.aspx
> The format is: `[{< GUID of client-side extension >}{< GUID of MMC extension >}{< GUID of second MMC extension if appropriate >}][repeat first section as appropriate].`

Added array sorter, Windows assumes the list is sorted and won't process the group policy if not positioned properly.
See https://social.msdn.microsoft.com/Forums/en-US/70264a14-579e-4064-887d-4d3743af9a29/msgpol-incorrect-description-for-gpcmachineextensionnames-and-maybe-gpcuserextensionnames
> I had a discussion with Product Group and they confirmed that the CSE guids need to be in sorted order otherwise processing stops at the one that is out of sequence.

This may not be the perfect solution but it's working for me and is probably a good starting point.